### PR TITLE
save memory by not re-creating readable objects from JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irem",
-  "version": "1.1.0-RC1",
+  "version": "1.1.0-RC3",
   "description": "Search for any city in any language in Earth.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irem",
-  "version": "1.1.0-RC2",
+  "version": "1.1.0-RC1",
   "description": "Search for any city in any language in Earth.",
   "license": "MIT",
   "repository": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -392,7 +392,7 @@ export function isDefined<T>(a: T | undefined | null): a is NonNullable<T> {
  * @param {Set<T>} setA
  * @param {Set<T>} setB
  */
-export function uniteSets<T>(setA: Set<T>, setB: Array<T>) {
+export function uniteSets<T>(setA: Set<T>, setB: Set<T>) {
   for (const elem of setB) {
     setA.add(elem);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -392,7 +392,7 @@ export function isDefined<T>(a: T | undefined | null): a is NonNullable<T> {
  * @param {Set<T>} setA
  * @param {Set<T>} setB
  */
-export function uniteSets<T>(setA: Set<T>, setB: Set<T>) {
+export function uniteSets<T>(setA: Set<T>, setB: Array<T>) {
   for (const elem of setB) {
     setA.add(elem);
   }


### PR DESCRIPTION
- delete `TrieNode` and re-use the existing JSON object for Trie searches